### PR TITLE
new way for parsing revision next

### DIFF
--- a/api/blocks/blocks.go
+++ b/api/blocks/blocks.go
@@ -30,7 +30,7 @@ func New(repo *chain.Repository, bft bft.Finalizer) *Blocks {
 }
 
 func (b *Blocks) handleGetBlock(w http.ResponseWriter, req *http.Request) error {
-	revision, err := utils.ParseRevision(mux.Vars(req)["revision"])
+	revision, err := utils.ParseRevision(mux.Vars(req)["revision"], false)
 	if err != nil {
 		return utils.BadRequest(errors.WithMessage(err, "revision"))
 	}

--- a/api/utils/revisions.go
+++ b/api/utils/revisions.go
@@ -6,53 +6,54 @@
 package utils
 
 import (
+	"errors"
 	"math"
 	"strconv"
 
-	"github.com/pkg/errors"
 	"github.com/vechain/thor/v2/bft"
+	"github.com/vechain/thor/v2/block"
 	"github.com/vechain/thor/v2/chain"
+	"github.com/vechain/thor/v2/state"
 	"github.com/vechain/thor/v2/thor"
 )
 
-type Revision = interface{}
+const (
+	revBest      int64 = -1
+	revFinalized int64 = -2
+	revNext      int64 = -3
+)
 
-func GetSummary(revision Revision, repo *chain.Repository, bft bft.Finalizer) (s *chain.BlockSummary, err error) {
-	var id thor.Bytes32
-	switch revision := revision.(type) {
-	case thor.Bytes32:
-		id = revision
-	case uint32:
-		id, err = repo.NewBestChain().GetBlockID(revision)
-		if err != nil {
-			return
-		}
-	case string:
-		id = bft.Finalized()
-	default:
-		id = repo.BestBlockSummary().Header.ID()
-	}
-	summary, err := repo.GetBlockSummary(id)
-	if err != nil {
-		return nil, err
-	}
-	return summary, nil
+type Revision struct {
+	val interface{}
+}
+
+func (rev *Revision) IsNext() bool {
+	return rev.val == revNext
 }
 
 // ParseRevision parses a query parameter into a block number or block ID.
-func ParseRevision(revision string) (Revision, error) {
+func ParseRevision(revision string, allowNext bool) (*Revision, error) {
 	if revision == "" || revision == "best" {
-		return nil, nil
+		return &Revision{revBest}, nil
 	}
+
 	if revision == "finalized" {
-		return revision, nil
+		return &Revision{revFinalized}, nil
 	}
+
+	if revision == "next" {
+		if !allowNext {
+			return nil, errors.New("invalid revision: next is not allowed")
+		}
+		return &Revision{revNext}, nil
+	}
+
 	if len(revision) == 66 || len(revision) == 64 {
 		blockID, err := thor.ParseBytes32(revision)
 		if err != nil {
 			return nil, err
 		}
-		return blockID, nil
+		return &Revision{blockID}, nil
 	}
 	n, err := strconv.ParseUint(revision, 0, 0)
 	if err != nil {
@@ -61,15 +62,79 @@ func ParseRevision(revision string) (Revision, error) {
 	if n > math.MaxUint32 {
 		return nil, errors.New("block number out of max uint32")
 	}
-	return uint32(n), err
+	return &Revision{uint32(n)}, err
 }
 
-// ParseCodeCallRevision parses the revision query parameter for endpoints that may be estimating gas for new transactions.
-func ParseCodeCallRevision(revision string) (Revision, bool, error) {
-	if revision == "next" {
-		return nil, true, nil
+// GetSummary returns the block summary for the given revision,
+// revision required to be a deterministic block other than "next".
+func GetSummary(rev *Revision, repo *chain.Repository, bft bft.Finalizer) (sum *chain.BlockSummary, err error) {
+	var id thor.Bytes32
+	switch rev := rev.val.(type) {
+	case thor.Bytes32:
+		id = rev
+	case uint32:
+		id, err = repo.NewBestChain().GetBlockID(rev)
+		if err != nil {
+			return
+		}
+	case int64:
+		switch rev {
+		case revBest:
+			id = repo.BestBlockSummary().Header.ID()
+		case revFinalized:
+			id = bft.Finalized()
+		}
+	}
+	if id.IsZero() {
+		return nil, errors.New("invalid revision")
+	}
+	summary, err := repo.GetBlockSummary(id)
+	if err != nil {
+		return nil, err
+	}
+	return summary, nil
+}
+
+// GetHeaderAndState returns the block header and state for the given revision,
+// this function supports the "next" revision.
+func GetHeaderAndState(rev *Revision, repo *chain.Repository, bft bft.Finalizer, stater *state.Stater) (*block.Header, *state.State, error) {
+	if rev.IsNext() {
+		best := repo.BestBlockSummary()
+
+		// here we create a fake(no signature) "next" block header which reused most part of the parent block
+		// but set the timestamp and number to the next block. The following parameters will be used in the evm
+		// number, timestamp, total score, gas limit, beneficiary and "signer"
+		// since the fake block is not signed, the signer is the zero address, it is important that the subsequent
+		// call to header.Signer(), the error should be ignored.
+		builder := new(block.Builder).
+			ParentID(best.Header.ID()).
+			Timestamp(best.Header.Timestamp() + thor.BlockInterval).
+			TotalScore(best.Header.TotalScore()).
+			GasLimit(best.Header.GasLimit()).
+			GasUsed(best.Header.GasUsed()).
+			Beneficiary(best.Header.Beneficiary()).
+			StateRoot(best.Header.StateRoot()).
+			ReceiptsRoot(best.Header.ReceiptsRoot()).
+			TransactionFeatures(best.Header.TxsFeatures()).
+			Alpha(best.Header.Alpha())
+
+		// here we skipped the block's tx list thus header.txRoot will be an empty root
+		// since txRoot won't be supplied into the evm, it's safe to skip it.
+		if best.Header.COM() {
+			builder.COM()
+		}
+		mocked := builder.Build()
+
+		// state is also reused from the parent block
+		st := stater.NewState(best.Header.StateRoot(), best.Header.Number(), best.Conflicts, best.SteadyNum)
+
+		return mocked.Header(), st, nil
+	}
+	sum, err := GetSummary(rev, repo, bft)
+	if err != nil {
+		return nil, nil, err
 	}
 
-	res, err := ParseRevision(revision)
-	return res, false, err
+	st := stater.NewState(sum.Header.StateRoot(), sum.Header.Number(), sum.Conflicts, sum.SteadyNum)
+	return sum.Header, st, nil
 }


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List
any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [x] Test A
- [x] Test B

**Test Configuration**:

* Go Version:
* Hardware:
* Docker Version:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates revision handling in `blocks.go` and `accounts.go` functions. It introduces a new parameter and refactors related functions.

### Detailed summary
- Updated `ParseRevision` function with an additional boolean parameter
- Modified handling of revision in multiple functions in `blocks.go` and `accounts.go`
- Introduced `GetHeaderAndState` function to retrieve header and state based on revision

> The following files were skipped due to too many changes: `api/accounts/accounts.go`, `api/utils/revisions.go`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->