### PR TITLE
feat: add goreleaser to publish binaries

### DIFF
--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -19,6 +19,10 @@ jobs:
         with:
           node-version: '20'
 
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
       - name: Validate Tag
         run: |
           node -e "if (!/^v\d+\.\d+\.\d+$/.test('${{ github.ref_name }}')) { console.error('Invalid version provided');process.exit(1);}"
@@ -43,6 +47,14 @@ jobs:
             echo "Tag is not an official release"
             exit 1
           fi
+
+      - name: Publish Binaries
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: '~> v2'
+          args: release --clean --timeout=90m
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-docker-image:
     name: Publish Docker Image

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ package.json
 coverage.out
 
 .idea
+
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,47 @@
+# goreleaser is currently used to attach binaries to github releases
+# it can be exteneded in the future to also publish docker images, brew, chocolatey, etc.
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+    - go mod vendor
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    main: ./cmd/thor/main.go
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    main: ./cmd/disco/main.go
+    command: make disco
+
+release:
+  github:
+    owner: vechain
+    name: thor
+
+archives:
+  - format: tar.gz
+    wrap_in_directory: true
+    format_overrides:
+      - goos: windows
+        format: zip
+    name_template: '{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    files:
+      - LICENSE
+      - README.md


### PR DESCRIPTION
# Description

Test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the GitHub Actions workflow to use Go 1.22, adds a step to publish binaries using `goreleaser`, and enhances the `.goreleaser.yaml` configuration for future extensibility.

### Detailed summary
- Updated GitHub Actions workflow to use Go 1.22
- Added step to publish binaries using `goreleaser`
- Enhanced `.goreleaser.yaml` for future extensibility and added build configurations

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->